### PR TITLE
Update dependencies to work with current nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ hyper = "0.7"
 # Escaping of query parameters
 url = "0.5"
 # JSON serialization and deserialization
-serde = "0.7"
-serde_json = "0.7"
-serde_macros = "0.7"
+serde = "0.8"
+serde_json = "0.8"
+serde_derive = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 #![doc(html_root_url = "http://mmitteregger.github.io/rust-twitch-client")]
-#![feature(custom_derive, plugin)]
-#![plugin(serde_macros)]
 #![warn(missing_docs)]
 #![cfg_attr(test, deny(missing_docs))]
 #![cfg_attr(test, deny(warnings))]
@@ -33,6 +31,7 @@
 #[macro_use] extern crate hyper;
 extern crate url;
 extern crate serde;
+#[macro_use] extern crate serde_derive;
 extern crate serde_json;
 
 pub mod model;


### PR DESCRIPTION
Hi,

I couldn't build the current branch on nightly:

rustc 1.17.0-nightly (8c4f2c64c 2017-03-22)
cargo 0.19.0-nightly (c995e9eb5 2017-03-17)             

This should update the dependencies to build with the new serde crates.
As seen here: https://users.rust-lang.org/t/serde-transitioning-to-macros-1-1/7437
                                                                                                    